### PR TITLE
Unitful support

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,11 +1,13 @@
+# This file is machine-generated - editing it directly is not advised
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "ec61a16eed883ad0cfa002d7489b3ce6d039bb9a"
+git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "1.4.0"
+version = "2.1.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -16,18 +18,18 @@ deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
-deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[InteractiveUtils]]
-deps = ["LinearAlgebra", "Markdown"]
+deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JSON]]
-deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
-git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.20.0"
+version = "0.21.0"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -48,6 +50,12 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "ef0af6c8601db18c282d092ccbd2f01f3f0cd70b"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "0.3.7"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -91,8 +99,14 @@ deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[UUIDs]]
-deps = ["Random"]
+deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Unitful]]
+deps = ["LinearAlgebra", "Random"]
+git-tree-sha1 = "92bdf0ccfa9612b167d0adaadef832a09971ceb0"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "0.17.0"

--- a/Project.toml
+++ b/Project.toml
@@ -7,3 +7,10 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7
-JSON  0.5
-Compat
-Libdl

--- a/src/CoolProp.jl
+++ b/src/CoolProp.jl
@@ -327,14 +327,12 @@ function set_config(key::AbstractString, val::Bool)
 end
 
 export CoolProp_parameters, CoolProp_fluids;
+import Markdown
 """
-# CoolProp parameters table, to build run `CoolProp.buildparameters()`
-
-$(isfile(abspath(@__FILE__, "..", "parameters.table")) ? readstring(abspath(@__FILE__, "..", "parameters.table")) : "")
+Show the CoolProp parameters table
 """
-const CoolProp_parameters = "Type `?CoolProp_arameters` to get a list of all CoolProp parameters."
-buildparameters() = begin
-    logf = open("parameters.table", "w");
+function CoolProp_parameters()
+    logf = IOBuffer()
     println(logf, "Paramerer |Description |Unit |Comment ");
     println(logf, ":---------|:-----------|:----|:-------" );
     counter = 0;
@@ -357,16 +355,13 @@ buildparameters() = begin
         end
         println(logf, "$p" * " | " * longunit * " | " * note);
     end
-    close(logf);
+    return Markdown.parse(String(take!(logf)))
 end
 """
-# CoolProp fluids table, to build run `CoolProp.buildfluids()`
-
-$(isfile(abspath(@__FILE__, "..", "fluids.table")) ? readstring(abspath(@__FILE__, "..", "fluids.table")) : "")
+Show the CoolProp fluids table
 """
-const CoolProp_fluids = "Type `?CoolProp_fluids` to get a list of all CoolProp fluids."
-buildfluids() = begin
-    logf = open("fluids.table", "w");
+function CoolProp_fluids()
+    logf = IOBuffer()
     println(logf, "ID |Name |Alias |CAS |Pure |Formula |BibTeX ");
     println(logf, ":--|:----|:-----|:---|:----|:-------|:------");
     id = 0;
@@ -382,7 +377,7 @@ buildfluids() = begin
         end
         print(logf, "\n");
     end
-    close(logf);
+    return Markdown.parse(String(take!(logf)))
 end
 # ---------------------------------
 #       Information functions


### PR DESCRIPTION
This is probably still too rough around the edges, but it is an attempt to integrate some Unitful.jl support. Additionally:
* `Coolprop_fluids` and `Coolprop_parameter` are now functions that return a markdown table, this seems more compatible with the automatic precompilation in Julia 1.x.
* Removed `REQUIRE` and updated Project and Manifest files