### PR TITLE
update package url and add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,20 @@ This is not my work, and all the credit goes to the cool [CoolProp contributors]
 
 ## Installation
 ```julia
-Pkg.clone("https://github.com/vimalaad/CoolProp.jl.git")
-Pkg.build("CoolProp") # to download the latest binaries
+using Pkg
+Pkg.add(url="https://github.com/CoolProp/CoolProp.jl.git")
 ```
-or
-```julia
-Pkg.clone("https://github.com/vimalaad/CoolProp.jl.git")
-Pkg.checkout("CoolProp", "nightly")
-Pkg.build("CoolProp") # to download the nightly binaries
-```
-## Note
+### Note
 The installer downloads related libraries respect to machine OS & wordsize. Please let me know if it does not work for you. As an alternative, you can download the binaries for your OS from [here](https://sourceforge.net/projects/coolprop/files/CoolProp/6.1.0/shared_library/)
+
+## Usage
+The API is described in http://www.coolprop.org/coolprop/HighLevelAPI.html.
+```julia
+using CoolProp
+PropsSI("T", "P", 101325.0, "Q", 0.0, "Water")
+373.1242958476844
+```
+
 ## Development
 For development, it is possible to include a custom wrapper from `ENV["TestingPath"]`, then:  
 ```julia


### PR DESCRIPTION
Thanks for creating this wrapper, it works nicely.
This PR a new take at #9, since `Pkg.clone` has been removed
(could not determine when from julia or Pkg changelogs).
It should fix #12 and #10.

Installation is simplified and smooth, tested with `julia-1.6.1`.

`CoolProp/CoolProp.jl` is now ahead of the original.
Removed `nightly` as it is 5 years old.

And added an example and a link to the API.
