### PR TITLE
add fugacity funcs compatible with Sept 2023 CoolProp master branch

### DIFF
--- a/src/CoolProp.jl
+++ b/src/CoolProp.jl
@@ -853,7 +853,6 @@ function AbstractState_update(handle::Clong, input_pair::AbstractString, value1:
 end
 
 #TODO: these functions will not work with CoolProp_jll 6.5. Needs new version released of current master from Sept 2023
-#TODO: update output of example func call
 """
     AbstractState_get_fugacity(handle::Clong, i::Integer)
 
@@ -870,18 +869,17 @@ julia> pq_inputs = get_input_pair_index("PQ_INPUTS");
 julia> t = get_param_index("T");
 julia> AbstractState_set_fractions(handle, [0.4, 0.6]);
 julia> AbstractState_update(handle, pq_inputs, 101325, 0);
-julia> AbstractState_get_fugacity(handle, 1)
-TODO: update output
+julia> AbstractState_get_fugacity(handle, 0)
+30227.119385400914
 julia> AbstractState_free(handle);
 ```
 """
-function AbstractState_get_fugacity(handle::Clong, i::Integer) #TODO: maybe type this as an integer?
-    ccall( (:AbstractState_get_fugacity, libcoolprop), Nothing, (Clong, Clong, Ref{Clong}, Ptr{UInt8}, Clong), handle, i, errcode, message_buffer::Array{UInt8, 1}, buffer_length)
+function AbstractState_get_fugacity(handle::Clong, i::Integer)
+    output = ccall( (:AbstractState_get_fugacity, libcoolprop), Cdouble, (Clong, Clong, Ref{Clong}, Ptr{UInt8}, Clong), handle, i, errcode, message_buffer::Array{UInt8, 1}, buffer_length)
     raise(errcode, message_buffer)
-    return nothing
+    return output
 end
 
-#TODO: update output of example func call
 """
     AbstractState_get_fugacity_coefficient(handle::Clong, i::Real)
 
@@ -898,15 +896,15 @@ julia> pq_inputs = get_input_pair_index("PQ_INPUTS");
 julia> t = get_param_index("T");
 julia> AbstractState_set_fractions(handle, [0.4, 0.6]);
 julia> AbstractState_update(handle, pq_inputs, 101325, 0);
-julia> AbstractState_get_fugacity_coefficient(handle, 1)
-TODO: update output
+julia> AbstractState_get_fugacity_coefficient(handle, 0)
+0.7457961851803392
 julia> AbstractState_free(handle);
 ```
 """
 function AbstractState_get_fugacity_coefficient(handle::Clong, i::Integer) #TODO: maybe type this as an integer?
-    ccall( (:AbstractState_get_fugacity_coefficient, libcoolprop), Nothing, (Clong, Clong, Ref{Clong}, Ptr{UInt8}, Clong), handle, i, errcode, message_buffer::Array{UInt8, 1}, buffer_length)
+    output = ccall( (:AbstractState_get_fugacity_coefficient, libcoolprop), Cdouble, (Clong, Clong, Ref{Clong}, Ptr{UInt8}, Clong), handle, i, errcode, message_buffer::Array{UInt8, 1}, buffer_length)
     raise(errcode, message_buffer)
-    return nothing
+    return output
 end
 
 """

--- a/src/CoolProp.jl
+++ b/src/CoolProp.jl
@@ -112,7 +112,7 @@ function _get_unit(param::AbstractString)
     end
     # Otherwise use the normal parameter info
     unit_str = "-"
-    try 
+    try
         unit_str = get_parameter_information_string(param, "units")
     catch
     end
@@ -852,6 +852,63 @@ function AbstractState_update(handle::Clong, input_pair::AbstractString, value1:
     return nothing
 end
 
+#TODO: these functions will not work with CoolProp_jll 6.5. Needs new version released of current master from Sept 2023
+#TODO: update output of example func call
+"""
+    AbstractState_get_fugacity(handle::Clong, i::Integer)
+
+Return the fugacity of species `i`
+
+# Arguments
+* `handle`: The integer handle for the state class stored in memory
+* `i`: The index of the species
+
+# Example
+```julia
+julia> handle = AbstractState_factory("HEOS", "Water&Ethanol");
+julia> pq_inputs = get_input_pair_index("PQ_INPUTS");
+julia> t = get_param_index("T");
+julia> AbstractState_set_fractions(handle, [0.4, 0.6]);
+julia> AbstractState_update(handle, pq_inputs, 101325, 0);
+julia> AbstractState_get_fugacity(handle, 1)
+TODO: update output
+julia> AbstractState_free(handle);
+```
+"""
+function AbstractState_get_fugacity(handle::Clong, i::Integer) #TODO: maybe type this as an integer?
+    ccall( (:AbstractState_get_fugacity, libcoolprop), Nothing, (Clong, Clong, Ref{Clong}, Ptr{UInt8}, Clong), handle, i, errcode, message_buffer::Array{UInt8, 1}, buffer_length)
+    raise(errcode, message_buffer)
+    return nothing
+end
+
+#TODO: update output of example func call
+"""
+    AbstractState_get_fugacity_coefficient(handle::Clong, i::Real)
+
+Return the fugacity coefficient of species `i`
+
+# Arguments
+* `handle`: The integer handle for the state class stored in memory
+* `i`: The index of the species
+
+# Example
+```julia
+julia> handle = AbstractState_factory("HEOS", "Water&Ethanol");
+julia> pq_inputs = get_input_pair_index("PQ_INPUTS");
+julia> t = get_param_index("T");
+julia> AbstractState_set_fractions(handle, [0.4, 0.6]);
+julia> AbstractState_update(handle, pq_inputs, 101325, 0);
+julia> AbstractState_get_fugacity_coefficient(handle, 1)
+TODO: update output
+julia> AbstractState_free(handle);
+```
+"""
+function AbstractState_get_fugacity_coefficient(handle::Clong, i::Integer) #TODO: maybe type this as an integer?
+    ccall( (:AbstractState_get_fugacity_coefficient, libcoolprop), Nothing, (Clong, Clong, Ref{Clong}, Ptr{UInt8}, Clong), handle, i, errcode, message_buffer::Array{UInt8, 1}, buffer_length)
+    raise(errcode, message_buffer)
+    return nothing
+end
+
 """
     AbstractState_keyed_output(handle::Clong, param::Clong)
 
@@ -1345,7 +1402,7 @@ function AbstractState_all_critical_points(handle::Clong, length::Integer)
     return  AbstractState_all_critical_points(handle, length, T, p, rhomolar, stable)
 end
 
-for symorigin = [:PropsSI, :PhaseSI, :K2F, :F2K, :HAPropsSI, :AbstractState_factory, :AbstractState_free, :AbstractState_set_fractions, :AbstractState_update, :AbstractState_keyed_output, :AbstractState_output, :AbstractState_specify_phase, :AbstractState_unspecify_phase, :AbstractState_update_and_common_out, :AbstractState_update_and_1_out, :AbstractState_update_and_5_out, :AbstractState_set_binary_interaction_double, :AbstractState_set_cubic_alpha_C, :AbstractState_set_fluid_parameter_double, :AbstractState_first_saturation_deriv, :AbstractState_first_partial_deriv, :AbstractState_build_phase_envelope, :AbstractState_build_spinodal, :AbstractState_all_critical_points, :AbstractState_get_phase_envelope_data, :AbstractState_get_spinodal_data]
+for symorigin = [:PropsSI, :PhaseSI, :K2F, :F2K, :HAPropsSI, :AbstractState_factory, :AbstractState_free, :AbstractState_set_fractions, :AbstractState_update, :AbstractState_get_fugacity, :AbstractState_get_fugacity_coefficient, :AbstractState_keyed_output, :AbstractState_output, :AbstractState_specify_phase, :AbstractState_unspecify_phase, :AbstractState_update_and_common_out, :AbstractState_update_and_1_out, :AbstractState_update_and_5_out, :AbstractState_set_binary_interaction_double, :AbstractState_set_cubic_alpha_C, :AbstractState_set_fluid_parameter_double, :AbstractState_first_saturation_deriv, :AbstractState_first_partial_deriv, :AbstractState_build_phase_envelope, :AbstractState_build_spinodal, :AbstractState_all_critical_points, :AbstractState_get_phase_envelope_data, :AbstractState_get_spinodal_data]
     sym = Symbol(lowercase(string(symorigin)))
     @eval const $sym = $symorigin
     @eval export $sym, $symorigin

--- a/test/testLow.jl
+++ b/test/testLow.jl
@@ -68,9 +68,9 @@ pq_inputs = get_input_pair_index("PQ_INPUTS")
 t = get_param_index("T")
 AbstractState_set_fractions(handle, [0.4, 0.6])
 AbstractState_update(handle,pq_inputs,101325, 0)
-i = 1 #index of water in mixture
-AbstractState_get_fugacity(handle, i)
-AbstractState_get_fugacity_coefficient(handle, i)
+i = 0 #index of water in mixture
+f_0 = AbstractState_get_fugacity(handle, i)
+fc_0 = AbstractState_get_fugacity_coefficient(handle, i)
 if (haskey(ENV, "includelocalwrapper") && ENV["includelocalwrapper"]=="on")
     T, p, rhomolar, hmolar, smolar = AbstractState_update_and_common_out(handle, pq_inputs, [101325.0], [0.0], 1)
     temp_, p, rhomolar, hmolar, smolar = AbstractState_update_and_common_out(handle, "PQ_INPUTS", [101325.0], [0.0], 1)

--- a/test/testLow.jl
+++ b/test/testLow.jl
@@ -1,3 +1,6 @@
+using CoolProp
+using Test
+
 #low
 @info "********* Low Level Api *********"
 const HEOS_BACKEND_FAMILY = "HEOS"
@@ -65,6 +68,9 @@ pq_inputs = get_input_pair_index("PQ_INPUTS")
 t = get_param_index("T")
 AbstractState_set_fractions(handle, [0.4, 0.6])
 AbstractState_update(handle,pq_inputs,101325, 0)
+i = 1 #index of water in mixture
+AbstractState_get_fugacity(handle, i)
+AbstractState_get_fugacity_coefficient(handle, i)
 if (haskey(ENV, "includelocalwrapper") && ENV["includelocalwrapper"]=="on")
     T, p, rhomolar, hmolar, smolar = AbstractState_update_and_common_out(handle, pq_inputs, [101325.0], [0.0], 1)
     temp_, p, rhomolar, hmolar, smolar = AbstractState_update_and_common_out(handle, "PQ_INPUTS", [101325.0], [0.0], 1)
@@ -81,7 +87,7 @@ else
     out1=[0.0]; out2=[0.0]; out3=[0.0]; out4=[0.0]; out5=[0.0]; out1_=[0.0]
     AbstractState_update_and_5_out(handle, pq_inputs, [101325.0], [0.0],1, [t, t, t, t, t], out1, out2, out3, out4, out5)
     AbstractState_update_and_5_out(handle, "PQ_INPUTS", [101325.0], [0.0],1, ["T", "T", "T", "T", "T"], out1_, out2, out3, out4, out5)
-end 
+end
 if Sys.isapple()
     @test AbstractState_keyed_output(handle,t) ≈ 352.3522212978604
     @test AbstractState_output(handle,"T") ≈ 352.3522212978604


### PR DESCRIPTION
Closes #31 

Fugacity lookups did not exist in `CoolProp.jl`. They are added here. However, a fugacity function in the base C++ which is compatible with Julia wrapping did not exist previously. The C++ code was added successfully. https://github.com/CoolProp/CoolProp/pull/2286 

This will be a draft PR until `CoolProp` releases a new version that includes the change which is ahead of v6.5. Once that is released and `CoolProp_jll` is updated, this PR can be merged. 