### PR TITLE
add CoolProp development testing

### DIFF
--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -9,7 +9,10 @@ on:
       - '.github/**'
       - 'test/CoolPropDevLoader/**'
 
-concurrency:
+permissions:
+  contents: read
+
+  concurrency:
   # Skip intermediate builds: all builds except for builds on the `master` branch
   # Cancel intermediate builds: only pull request builds
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test-coolprop-dev:
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         julia_version:

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -1,0 +1,51 @@
+name: Unit Tests
+
+on:
+  - cron: '0 0 * * *'
+  - workflow_dispatch:
+
+concurrency:
+  # Skip intermediate builds: all builds except for builds on the `master` branch
+  # Cancel intermediate builds: only pull request builds
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  test-coolprop-dev:
+    timeout-minutes: 40
+    strategy:
+      matrix:
+        os:
+        - "ubuntu-latest"
+        julia_version:
+        - "nightly"
+        - "1"
+        - "1.10"
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - uses: julia-actions/setup-julia@v3
+      with:
+        arch: ${{ matrix.julia_arch }}
+        version: ${{ matrix.julia_version }}
+    - uses: julia-actions/cache@v3
+
+    - name: add CoolPropDevLoader
+      shell: julia --color=yes --project=. {0}
+      run: |
+        using Pkg
+        Pkg.develop(path="test/CoolPropDevLoader")
+
+    - name: test dev
+      shell: julia --color=yes --project=test {0}
+      run: |
+        using Pkg
+        Pkg.develop(path="test/CoolPropDevLoader")
+        using CoolPropDevLoader
+        CoolPropDevLoader.use_dev_library(CoolPropDevLoader.CompileCoolPropFromSourceforge())
+
+    - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -25,6 +25,8 @@ jobs:
         - "nightly"
         - "1"
         - "1.10"
+        arch:
+        - x64
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -45,7 +45,7 @@ jobs:
         using Pkg
         Pkg.develop(path="test/CoolPropDevLoader")
 
-    - name: test dev
+    - name: Compiling CoolProp
       shell: julia --color=yes --compiled-modules=no --project=test {0}
       run: |
         using Pkg

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -47,11 +47,11 @@ jobs:
         Pkg.develop(path="test/CoolPropDevLoader")
 
     - name: test dev
-      shell: julia --color=yes --project=test {0}
+      shell: julia --color=yes --compiled-modules=no --project=test {0}
       run: |
         using Pkg
         Pkg.develop(path="test/CoolPropDevLoader")
-        Pkg.develop()
+        Pkg.develop(path = "")
         using CoolPropDevLoader
         CoolPropDevLoader.use_dev_library(CoolPropDevLoader.CompileCoolPropFromSourceforge())
 

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   - cron: '0 0 * * *'
-  - workflow_dispatch:
+  - workflow_dispatch
 
 concurrency:
   # Skip intermediate builds: all builds except for builds on the `master` branch

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -21,8 +21,7 @@ jobs:
     strategy:
       matrix:
         julia_version:
-          - 'lts'
-          - '1'
+          - '1.12'
         os:
           - ubuntu-latest
         julia_arch:
@@ -53,5 +52,6 @@ jobs:
         Pkg.develop(path="test/CoolPropDevLoader")
         using CoolPropDevLoader
         CoolPropDevLoader.use_dev_library(CoolPropDevLoader.CompileCoolPropFromSourceforge())
+        Pkg.add("Test")
 
     - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -7,6 +7,7 @@ on:
   push:
     paths:
       - '.github/**'
+      - 'test/CoolPropDevLoader/**'
 
 concurrency:
   # Skip intermediate builds: all builds except for builds on the `master` branch

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -1,8 +1,9 @@
-name: Unit Tests
+name: Development Tests
 
 on:
-  - cron: '0 0 * * *'
-  - workflow_dispatch
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
 
 concurrency:
   # Skip intermediate builds: all builds except for builds on the `master` branch

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test-coolprop-dev:
-    timeout-minutes: 40
+    timeout-minutes: 20
     strategy:
       matrix:
         julia_version:

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -19,14 +19,13 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
+        version:
+          - 'lts'
+          - '1'
         os:
-        - "ubuntu-latest"
-        julia_version:
-        - "nightly"
-        - "1"
-        - "1.10"
+          - ubuntu-latest
         arch:
-        - x64
+          - x64
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -55,3 +55,4 @@ jobs:
         Pkg.add("Test")
 
     - uses: julia-actions/julia-runtest@v1
+    

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+  push:
+    paths:
+      - '.github/**'
 
 concurrency:
   # Skip intermediate builds: all builds except for builds on the `master` branch

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -51,7 +51,6 @@ jobs:
       run: |
         using Pkg
         Pkg.develop(path="test/CoolPropDevLoader")
-        Pkg.develop(path = "")
         using CoolPropDevLoader
         CoolPropDevLoader.use_dev_library(CoolPropDevLoader.CompileCoolPropFromSourceforge())
 

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -19,12 +19,12 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        version:
+        julia_version:
           - 'lts'
           - '1'
         os:
           - ubuntu-latest
-        arch:
+        julia_arch:
           - x64
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -51,6 +51,7 @@ jobs:
       run: |
         using Pkg
         Pkg.develop(path="test/CoolPropDevLoader")
+        Pkg.develop()
         using CoolPropDevLoader
         CoolPropDevLoader.use_dev_library(CoolPropDevLoader.CompileCoolPropFromSourceforge())
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.2.2"
 [deps]
 CoolProp_jll = "3351c21f-4feb-5f29-afb9-f4fcb0e27549"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 CoolProp_jll = "6.6, 7.1"
 julia = "1.3"
-Unitful="1"
+Preferences = "1"
+Unitful = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ using Unitful: °C, Pa
 HAPropsSI("H", "Tdb", 20°C, "RH", 0.5, "P", 101325Pa)
 38622.83892391293 J kg⁻¹
 ```
+
+## Using development versions of CoolProp
+
+You can point CoolProp.jl to use tyour own version of CoolProp by using `Preferences.jl`:
+
+```julia
+using CoolProp, Preferences
+@set_reference!(CoolProp,"coolprop_library" = my_path_to_library)
+```

--- a/README.md
+++ b/README.md
@@ -39,12 +39,3 @@ using Unitful: °C, Pa
 HAPropsSI("H", "Tdb", 20°C, "RH", 0.5, "P", 101325Pa)
 38622.83892391293 J kg⁻¹
 ```
-
-## Using development versions of CoolProp
-
-You can point CoolProp.jl to use tyour own version of CoolProp by using `Preferences.jl`:
-
-```julia
-using CoolProp, Preferences
-@set_reference!(CoolProp,"coolprop_library" = my_path_to_library)
-```

--- a/src/CoolProp.jl
+++ b/src/CoolProp.jl
@@ -11,7 +11,7 @@ import CoolProp_jll
 end
 
 @static if VERSION >= v"1.6"
-    const libcoolprop = @load_preference("coolprop_library", CoolProp_jll.libcoolprop)
+    const libcoolprop = load_preference(CoolProp_jll,"coolprop_library", CoolProp_jll.libcoolprop)
 else
     const libcoolprop = CoolProp_jll.libcoolprop
 end

--- a/src/CoolProp.jl
+++ b/src/CoolProp.jl
@@ -1,8 +1,20 @@
 #__precompile__()
 module CoolProp
 
+
+
 import Unitful
-using CoolProp_jll
+import CoolProp_jll
+
+@static if VERSION >= v"1.6"
+    using Preferences
+end
+
+@static if VERSION >= v"1.6"
+    const libcoolprop = @load_preference("coolprop_library", CoolProp_jll.libcoolprop)
+else
+    const libcoolprop = CoolProp_jll.libcoolprop
+end
 
 ####################################################################################################################
 ####################################################################################################################

--- a/test/CoolProp.jl
+++ b/test/CoolProp.jl
@@ -1,6 +1,8 @@
 #__precompile__()
 module CoolProp
 
+@info "CoolProp library path: $(CoolProp.libcoolprop)"
+
 errcode = Ref{Clong}(0)
 const buffer_length = 20000
 message_buffer = Array(UInt8, buffer_length)

--- a/test/CoolPropDevLoader/Project.toml
+++ b/test/CoolPropDevLoader/Project.toml
@@ -1,5 +1,5 @@
 name = "CoolPropDevLoader"
-uuid = "e084ae63-2819-5025-826e-f8e611a84251"
+uuid = "1abf7821-c65a-4ba0-83a4-5660520f37c7"
 version = "1.0.0"
 
 [deps]

--- a/test/CoolPropDevLoader/Project.toml
+++ b/test/CoolPropDevLoader/Project.toml
@@ -9,7 +9,7 @@ CoolProp_jll = "3351c21f-4feb-5f29-afb9-f4fcb0e27549"
 
 [compat]
 Downloads = "1"
-julia = "1.3"
+julia = "1.6"
 Preferences = "1"
 CoolProp_jll = "6.6, 7.1"
 

--- a/test/CoolPropDevLoader/Project.toml
+++ b/test/CoolPropDevLoader/Project.toml
@@ -5,11 +5,13 @@ version = "1.0.0"
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+CoolProp_jll = "3351c21f-4feb-5f29-afb9-f4fcb0e27549"
 
 [compat]
 Downloads = "1"
 julia = "1.3"
 Preferences = "1"
+CoolProp_jll = ">= 0.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/CoolPropDevLoader/Project.toml
+++ b/test/CoolPropDevLoader/Project.toml
@@ -1,0 +1,18 @@
+name = "CoolPropDevLoader"
+uuid = "e084ae63-2819-5025-826e-f8e611a84251"
+version = "1.0.0"
+
+[deps]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+
+[compat]
+Downloads = "1"
+julia = "1.3"
+Preferences = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/CoolPropDevLoader/Project.toml
+++ b/test/CoolPropDevLoader/Project.toml
@@ -11,7 +11,7 @@ CoolProp_jll = "3351c21f-4feb-5f29-afb9-f4fcb0e27549"
 Downloads = "1"
 julia = "1.3"
 Preferences = "1"
-CoolProp_jll = ">= 0.1"
+CoolProp_jll = "6.6, 7.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -100,12 +100,12 @@ function use_dev_library(::CompileCoolPropFromSourceforge)
 end
 
 function use_dev_library(lib_src::String)
-    set_preferences!(COOLPROP_UUID,"coolprop_library" => lib_src, force = true)
+    set_preferences!((COOLPROP_UUID,"CoolProp"),"coolprop_library" => lib_src, force = true,active_project_only = false)
     @info "Preference set to $lib_src"
 end
 
 function use_default_library()
-    delete_preferences!(COOLPROP_UUID,"coolprop_library",force = true)
+    delete_preferences!((COOLPROP_UUID,"CoolProp"),"coolprop_library",force = true,active_project_only = false)
 end
 
 end #module

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -9,10 +9,10 @@ const COOLPROP_UUID = "e084ae63-2819-5025-826e-f8e611a84251"
 #only available in linux
 function compile_from_sourceforge()
     # 1. Configuration
-    download_url = SOURCEFORGE_URL
+    url = SOURCEFORGE_URL
     build_dir = joinpath(@__DIR__, "coolprop_build")  # Change as needed
     source_zip = joinpath(build_dir, "CoolProp_sources.zip")
-    extract_dir = joinpath(build_dir, "CoolProp")
+    extract_dir = build_dir  # We'll extract directly into build_dir, then locate source root
     lib_name = "libCoolProp.so"
     
     # 2. Create build directory
@@ -20,39 +20,59 @@ function compile_from_sourceforge()
     mkpath(extract_dir)
 
     # 3. Download the source zip
-    @info "Downloading CoolProp source from $download_url..."
-    # SourceForge redirects: we need to find the actual download link
-    # The nightly source is typically at:
-    # https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download
-    
+    @info "Downloading CoolProp source from $url..."
+    download_url = "https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download"
     Downloads.download(download_url, source_zip)
     
-    # 4. Extract the zip
+    # 4. Extract the zip into build_dir
     @info "Extracting source..."
     run(`unzip -q $source_zip -d $build_dir`)
     
-    # 5. Prepare for CMake build
-    cd(extract_dir) do
-        # Create build directory inside extracted source
-        build_subdir = joinpath(extract_dir, "build")
-        mkpath(build_subdir)
-        cd(build_subdir) do
-            # 6. Configure with CMake - build shared library
-            @info "Configuring with CMake..."
-            run(`cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCMAKE_BUILD_TYPE=Release`)
-            
-            # 7. Build
-            @info "Compiling CoolProp (this may take a few minutes)..."
-            run(`cmake --build . --config Release --parallel $(Sys.CPU_THREADS)`)
+    # 5. Find the actual source root: a directory that contains CMakeLists.txt
+    @info "Locating source root..."
+    function find_cmakelists_root(dir)
+        # Check if dir itself contains CMakeLists.txt
+        if isfile(joinpath(dir, "CMakeLists.txt"))
+            return dir
         end
+        # Otherwise, look for a subdirectory that contains it
+        for entry in readdir(dir)
+            path = joinpath(dir, entry)
+            if isdir(path) && isfile(joinpath(path, "CMakeLists.txt"))
+                return path
+            end
+        end
+        # If not found, search recursively (but be careful with deep structures)
+        for (root, dirs, files) in walkdir(dir)
+            if "CMakeLists.txt" in files
+                return root
+            end
+        end
+        error("Could not find CMakeLists.txt anywhere in $dir")
     end
     
-    # 8. Locate the generated shared library
-    # The library is typically in build/ or build/Release/
+    source_root = find_cmakelists_root(extract_dir)
+    @info "Source root found at: $source_root"
+    
+    # 6. Prepare for CMake build: create a build subdirectory inside source_root
+    build_subdir = joinpath(source_root, "build")
+    mkpath(build_subdir)
+    cd(build_subdir) do
+        # 7. Configure with CMake - build shared library
+        @info "Configuring with CMake..."
+        run(`cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCMAKE_BUILD_TYPE=Release`)
+        
+        # 8. Build
+        @info "Compiling CoolProp (this may take a few minutes)..."
+        run(`cmake --build . --config Release --parallel $(Sys.CPU_THREADS)`)
+    end
+    
+    # 9. Locate the generated shared library
+    # The library is typically in build/ or build/Release/ or build/lib/
     possible_paths = [
-        joinpath(extract_dir, "build", lib_name),
-        joinpath(extract_dir, "build", "Release", lib_name),
-        joinpath(extract_dir, "build", "lib", lib_name),
+        joinpath(source_root, "build", lib_name),
+        joinpath(source_root, "build", "Release", lib_name),
+        joinpath(source_root, "build", "lib", lib_name),
     ]
     
     lib_path = nothing
@@ -70,6 +90,10 @@ function compile_from_sourceforge()
     @info "CoolProp library built successfully at: $lib_path"
     return lib_path
 end
+
+# Usage
+lib_path = build_coolprop()
+@info "Library path: $lib_path"
 
 struct CompileCoolPropFromSourceforge end
 

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -100,12 +100,12 @@ function use_dev_library(::CompileCoolPropFromSourceforge)
 end
 
 function use_dev_library(lib_src::String)
-    set_preferences!((COOLPROP_UUID,"CoolProp"),"coolprop_library" => lib_src, force = true,active_project_only = false)
+    set_preferences!((COOLPROP_UUID,"CoolProp"),"coolprop_library" => lib_src, force = true,active_project_only = false,export_prefs = true)
     @info "Preference set to $lib_src"
 end
 
 function use_default_library()
-    delete_preferences!((COOLPROP_UUID,"CoolProp"),"coolprop_library",force = true,active_project_only = false)
+    delete_preferences!((COOLPROP_UUID,"CoolProp"),"coolprop_library",force = true,active_project_only = false,export_prefs = true)
 end
 
 end #module

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -2,6 +2,7 @@ module CoolPropDevLoader
 
 using Preferences
 using Downloads
+using CoolProp_jll
 
 const SOURCEFORGE_URL = "https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download"
 const COOLPROP_UUID = "e084ae63-2819-5025-826e-f8e611a84251"
@@ -95,17 +96,17 @@ struct CompileCoolPropFromSourceforge end
 
 function use_dev_library(::CompileCoolPropFromSourceforge)
     lib_src = compile_from_sourceforge()
-    set_preferences!(COOLPROP_UUID,"coolprop_library" => lib_src, force = true)
+    set_preferences!(CoolProp_jll,"coolprop_library" => lib_src, force = true)
     @info "Preference set to $lib_src"
 end
 
 function use_dev_library(lib_src::String)
-    set_preferences!((COOLPROP_UUID,"CoolProp"),"coolprop_library" => lib_src, force = true,active_project_only = false,export_prefs = true)
+    set_preferences!(CoolProp_jll,"coolprop_library" => lib_src, force = true,active_project_only = false,export_prefs = true)
     @info "Preference set to $lib_src"
 end
 
 function use_default_library()
-    delete_preferences!((COOLPROP_UUID,"CoolProp"),"coolprop_library",force = true,active_project_only = false,export_prefs = true)
+    delete_preferences!(CoolProp_jll,"coolprop_library",force = true,export_prefs = true)
 end
 
 end #module

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -3,13 +3,13 @@ module CoolPropDevLoader
 using Preferences
 using Downloads
 
-const SOURCEFORGE_URL = https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip
+const SOURCEFORGE_URL = "https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download"
 const COOLPROP_UUID = "e084ae63-2819-5025-826e-f8e611a84251"
 
 #only available in linux
 function compile_from_sourceforge()
     # 1. Configuration
-    download_url = "https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download"
+    download_url = SOURCEFORGE_URL
     build_dir = joinpath(@__DIR__, "coolprop_build")  # Change as needed
     source_zip = joinpath(build_dir, "CoolProp_sources.zip")
     extract_dir = joinpath(build_dir, "CoolProp")

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -17,7 +17,8 @@ function compile_from_sourceforge()
     
     # 2. Create build directory
     mkpath(build_dir)
-    
+    mkpath(extract_dir)
+
     # 3. Download the source zip
     @info "Downloading CoolProp source from $download_url..."
     # SourceForge redirects: we need to find the actual download link

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -1,0 +1,90 @@
+module CoolPropDevLoader
+
+using Preferences
+using Downloads
+
+const SOURCEFORGE_URL = https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip
+const COOLPROP_UUID = "e084ae63-2819-5025-826e-f8e611a84251"
+
+#only available in linux
+function compile_from_sourceforge()
+    # 1. Configuration
+    download_url = "https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download"
+    build_dir = joinpath(@__DIR__, "coolprop_build")  # Change as needed
+    source_zip = joinpath(build_dir, "CoolProp_sources.zip")
+    extract_dir = joinpath(build_dir, "CoolProp")
+    lib_name = "libCoolProp.so"
+    
+    # 2. Create build directory
+    mkpath(build_dir)
+    
+    # 3. Download the source zip
+    @info "Downloading CoolProp source from $download_url..."
+    # SourceForge redirects: we need to find the actual download link
+    # The nightly source is typically at:
+    # https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download
+    
+    Downloads.download(download_url, source_zip)
+    
+    # 4. Extract the zip
+    @info "Extracting source..."
+    run(`unzip -q $source_zip -d $build_dir`)
+    
+    # 5. Prepare for CMake build
+    cd(extract_dir) do
+        # Create build directory inside extracted source
+        build_subdir = joinpath(extract_dir, "build")
+        mkpath(build_subdir)
+        cd(build_subdir) do
+            # 6. Configure with CMake - build shared library
+            @info "Configuring with CMake..."
+            run(`cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCMAKE_BUILD_TYPE=Release`)
+            
+            # 7. Build
+            @info "Compiling CoolProp (this may take a few minutes)..."
+            run(`cmake --build . --config Release --parallel $(Sys.CPU_THREADS)`)
+        end
+    end
+    
+    # 8. Locate the generated shared library
+    # The library is typically in build/ or build/Release/
+    possible_paths = [
+        joinpath(extract_dir, "build", lib_name),
+        joinpath(extract_dir, "build", "Release", lib_name),
+        joinpath(extract_dir, "build", "lib", lib_name),
+    ]
+    
+    lib_path = nothing
+    for p in possible_paths
+        if isfile(p)
+            lib_path = p
+            break
+        end
+    end
+    
+    if lib_path === nothing
+        error("Could not find compiled library. Looked in: $(join(possible_paths, ", "))")
+    end
+    
+    @info "CoolProp library built successfully at: $lib_path"
+    return lib_path
+end
+
+struct CompileCoolPropFromSourceforge end
+
+function use_dev_library(::CompileCoolPropFromSourceforge)
+    lib_src = compile_from_sourceforge()
+    set_preferences!(COOLPROP_UUID,"coolprop_library" => lib_src, force = true)
+    @info "Preference set to $lib_src"
+end
+
+function use_dev_library(lib_src::String)
+    set_preferences!(COOLPROP_UUID,"coolprop_library" => lib_src, force = true)
+    @info "Preference set to $lib_src"
+end
+
+function use_default_library()
+    delete_preferences!(COOLPROP_UUID,"coolprop_library",force = true)
+end
+
+end #module

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -91,10 +91,6 @@ function compile_from_sourceforge()
     return lib_path
 end
 
-# Usage
-lib_path = build_coolprop()
-@info "Library path: $lib_path"
-
 struct CompileCoolPropFromSourceforge end
 
 function use_dev_library(::CompileCoolPropFromSourceforge)

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -25,7 +25,7 @@ function compile_from_sourceforge()
     
     # 4. Extract the zip into build_dir
     @info "Extracting source..."
-    run(`unzip -q $source_zip -d $build_dir`)
+    run(`unzip -qo $source_zip -d $build_dir`)
     
     # 5. Find the actual source root: a directory that contains CMakeLists.txt
     @info "Locating source root..."
@@ -99,7 +99,7 @@ function use_dev_library(::CompileCoolPropFromSourceforge)
 end
 
 function use_dev_library(lib_src::String)
-    set_preferences!(CoolProp_jll,"coolprop_library" => lib_src, force = true,active_project_only = false,export_prefs = true)
+    set_preferences!(CoolProp_jll,"coolprop_library" => lib_src, force = true)
     @info "Preference set to $lib_src"
 end
 

--- a/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
+++ b/test/CoolPropDevLoader/src/CoolPropDevLoader.jl
@@ -5,7 +5,6 @@ using Downloads
 using CoolProp_jll
 
 const SOURCEFORGE_URL = "https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download"
-const COOLPROP_UUID = "e084ae63-2819-5025-826e-f8e611a84251"
 
 #only available in linux
 function compile_from_sourceforge()
@@ -22,8 +21,7 @@ function compile_from_sourceforge()
 
     # 3. Download the source zip
     @info "Downloading CoolProp source from $url..."
-    download_url = "https://sourceforge.net/projects/coolprop/files/CoolProp/nightly/source/CoolProp_sources.zip/download"
-    Downloads.download(download_url, source_zip)
+    Downloads.download(SOURCEFORGE_URL, source_zip)
     
     # 4. Extract the zip into build_dir
     @info "Extracting source..."


### PR DESCRIPTION
This PR implements:

- a mini package in the Test folder that compiles CoolProp from the nightly source in sourceforge, and sets the `libcoolprop` constant to the new compiled library (via Preferences.jl).
- github action runner, that runs CoolProp.jl tests while using the nightly compiled version. i couldn't make the action run on julia LTS, but it runs on 1.12 - ubuntu-latest.

At the moment, the github action runs, and fails (because the fix for https://github.com/CoolProp/CoolProp/issues/3258 is still not merged)

The compiler code was done with assistance of an LLM, feel free to change it to something better.

CC @ibell :  At the moment, the yml is configured to run in CoolProp.jl, but you could run it in CoolProp instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduled “Development Tests” workflow and manual/run-on-change triggers for development testing.
  * Added support for switching to a locally compiled development version of the CoolProp library.
* **Bug Fixes**
  * Improved shared-library resolution at startup across Julia versions.
  * Added an informational message indicating which CoolProp library path is in use.
* **Documentation**
  * Minor formatting tweak to the humid-air `HAPropsSI` example.
* **Tests**
  * Introduced a dedicated development test project and updated test target configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->